### PR TITLE
bitnami/nginx

### DIFF
--- a/bitnami/nginx/templates/deployment.yaml
+++ b/bitnami/nginx/templates/deployment.yaml
@@ -64,6 +64,9 @@ spec:
         - name: git-clone-repository
           image: {{ include "nginx.cloneStaticSiteFromGit.image" . }}
           imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.cloneStaticSiteFromGit.gitClone.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitClone.command "context" $) | nindent 12 }}
           {{- else}}
@@ -91,6 +94,9 @@ spec:
         - name: git-repo-syncer
           image: {{ include "nginx.cloneStaticSiteFromGit.image" . }}
           imagePullPolicy: {{ .Values.cloneStaticSiteFromGit.image.pullPolicy | quote }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.cloneStaticSiteFromGit.gitSync.command }}
           command: {{- include "common.tplvalues.render" (dict "value" .Values.cloneStaticSiteFromGit.gitSync.command "context" $) | nindent 12 }}
           {{- else}}


### PR DESCRIPTION
**Description of the change**

Set containerSecurityContext for init container git-clone-repository and container git-repo-syncer like it is already implemented for container nginx. The change use the same variable `Values.containerSecurityContext` from https://github.com/bitnami/charts/blob/d35b691cc9f3d80c9867c222477d7b57387df767/bitnami/nginx/values.yaml#L175

**Benefits**

Resolve following error:
`Error: container has runAsNonRoot and image will run as root (pod: "nginx-ui-b4d585f65-66gm2_ui(31a3c332-573e-422c-8d3d-7992f90e3654)", container: git-clone-repository)`

**Possible drawbacks**

-

**Applicable issues**

-

**Additional information**

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here.-->

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
